### PR TITLE
feat(lora): opt-in PDL + atomic-add expand + adaptive kv_b block sizes

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -444,6 +444,14 @@ class Envs:
     # more accurate. Only helps at large K (>=~2-4K input dim) and low batch;
     # the heuristic returns SPLIT_K=1 (original path) otherwise. Opt-in.
     SGLANG_ENABLE_LORA_SHRINK_SPLIT_K = EnvBool(False)
+    # Programmatic Dependent Launch (PDL) for the LoRA Triton kernels (dense MLA shrink/expand,
+    # absorbed kv_b correction, dense MLP gate_up/down, MoE virtual-expert shrink/expand, and the
+    # routing-prep kernels). Each kernel issues its static loads (LoRA weights + routing metadata)
+    # in the PDL prologue, then `gdc_wait()`s for the producing kernel before reading the dynamic
+    # activation, overlapping weight/metadata loads with the tail of the prior kernel. Hopper+
+    # only; AND'd with is_arch_support_pdl() so it is a no-op on unsupported arch / HIP. Opt-in;
+    # default off until perf-measured.
+    SGLANG_LORA_ENABLE_PDL = EnvBool(False)
     # Skip-softmax threshold scale factor for TRT-LLM attention (prefill and decode separately).
     # None = standard attention. See https://arxiv.org/abs/2512.12087
     SGLANG_SKIP_SOFTMAX_PREFILL_THRESHOLD_SCALE_FACTOR = EnvFloat(None)

--- a/python/sglang/srt/lora/backend/base_backend.py
+++ b/python/sglang/srt/lora/backend/base_backend.py
@@ -5,6 +5,10 @@ import triton
 import triton.language as tl
 
 from sglang.srt.lora.backend.lmhead_mixing import LoRABackendLmHeadMixing
+from sglang.srt.lora.triton_ops.kernel_utils import (
+    lora_pdl_enabled,
+    lora_pdl_launch_kwargs,
+)
 from sglang.srt.lora.utils import LoRABatchInfo, MoELoRABatchInfo
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 
@@ -343,12 +347,15 @@ def _compute_moe_lora_info_kernel(
     num_segments,
     max_len,
     BLOCK_SIZE: tl.constexpr,
+    ENABLE_PDL: tl.constexpr,
 ):
     pid = tl.program_id(0)
     num_pid_m = tl.cdiv(max_len, BLOCK_SIZE)
 
     pid_seg = pid // num_pid_m
     pid_m = pid % num_pid_m
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_wait()
     seg_start = tl.load(seg_indptr_ptr + pid_seg)
     seg_end = tl.load(seg_indptr_ptr + pid_seg + 1)
     seg_len = seg_end - seg_start
@@ -363,6 +370,9 @@ def _compute_moe_lora_info_kernel(
         mask=pid_m == 0,
     )
     tl.store(token_lora_mapping_ptr + seg_start + offs, lora_id, mask=valid)
+
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_launch_dependents()
 
 
 def _compute_moe_lora_info(
@@ -407,6 +417,7 @@ def _compute_moe_lora_info(
             f"MoE LoRA token-mapping launch under-covers tokens: "
             f"{grid_size=} {block_size=} {num_tokens=}"
         )
+        enable_pdl = lora_pdl_enabled()
         _compute_moe_lora_info_kernel[(grid_size,)](
             seg_indptr,
             lora_ranks,
@@ -416,6 +427,8 @@ def _compute_moe_lora_info(
             weight_indices.numel(),
             max_len,
             BLOCK_SIZE=block_size,
+            ENABLE_PDL=enable_pdl,
+            **lora_pdl_launch_kwargs(enable_pdl),
         )
         return adapter_enabled, token_lora_mapping
 

--- a/python/sglang/srt/lora/triton_ops/gate_up_lora_b.py
+++ b/python/sglang/srt/lora/triton_ops/gate_up_lora_b.py
@@ -2,7 +2,11 @@ import torch
 import triton
 import triton.language as tl
 
-from sglang.srt.lora.triton_ops.kernel_utils import _resolve_token_positions
+from sglang.srt.lora.triton_ops.kernel_utils import (
+    _resolve_token_positions,
+    lora_pdl_enabled,
+    lora_pdl_launch_kwargs,
+)
 from sglang.srt.lora.utils import LoRABatchInfo
 
 
@@ -36,6 +40,7 @@ def _gate_up_lora_b_kernel(
     BLOCK_K: tl.constexpr,
     # For fused output scaling
     scalings,
+    ENABLE_PDL: tl.constexpr,
 ):
     """
     This kernel packs 2 sgemms (gate/up) into a single kernel. The multiplication
@@ -104,37 +109,37 @@ def _gate_up_lora_b_kernel(
     w_ptrs = (weights + w_index * w_stride_0 + n_start * w_stride_1) + (
         k_offset[:, None] * w_stride_2 + n_offset[None, :] * w_stride_1
     )
+    w_tile = tl.load(
+        w_ptrs,
+        mask=(k_offset[:, None] < K) & (n_offset[None, :] < output_dim),
+        other=0.0,
+    )
 
-    # Iterate to compute the block in output matrix
-    partial_sum = tl.zeros((BLOCK_S, BLOCK_N), dtype=tl.float32)
-    for k in range(0, tl.cdiv(K, BLOCK_K)):
-        x_tile = tl.load(
-            x_ptrs,
-            mask=(s_offset[:, None] < seg_len) & (k_offset[None, :] < K - k * BLOCK_K),
-            other=0.0,
-        )
-        w_tile = tl.load(
-            w_ptrs,
-            mask=(k_offset[:, None] < K - k * BLOCK_K)
-            & (n_offset[None, :] < output_dim),
-            other=0.0,
-        )
-        partial_sum += tl.dot(x_tile, w_tile)
-
-        x_ptrs += BLOCK_K * x_stride_1
-        w_ptrs += BLOCK_K * w_stride_2
-
-    # Store result to output matrix
-    partial_sum *= scaling
-    partial_sum = partial_sum.to(x.dtype.element_ty)
     output_ptr = (
         output
         + n_start * output_stride_1
         + (s_physical[:, None] * output_stride_0 + n_offset[None, :] * output_stride_1)
     )
     output_mask = (s_offset[:, None] < seg_len) & (n_offset[None, :] < output_dim)
-    partial_sum += tl.load(output_ptr, mask=output_mask)
-    tl.store(output_ptr, partial_sum, mask=output_mask)
+
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_wait()
+
+    # Iterate to compute the block in output matrix
+    x_tile = tl.load(
+        x_ptrs,
+        mask=(s_offset[:, None] < seg_len) & (k_offset[None, :] < K),
+        other=0.0,
+    )
+    partial_sum = tl.dot(x_tile, w_tile) * scaling
+
+    # Store result to output matrix
+    partial_sum *= scaling
+    partial_sum = partial_sum.to(x.dtype.element_ty)
+    tl.atomic_add(output_ptr, partial_sum, mask=output_mask, sem="relaxed")
+
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_launch_dependents()
 
 
 def gate_up_lora_b_fwd(
@@ -161,7 +166,7 @@ def gate_up_lora_b_fwd(
     assert input_dim == 2 * r
 
     BLOCK_S = 16
-    BLOCK_R = 16
+    BLOCK_R = triton.next_power_of_2(r)
     BLOCK_OUT = 64
 
     grid_b = (
@@ -176,6 +181,7 @@ def gate_up_lora_b_fwd(
         output = base_output
 
     sorted_by_adapter = batch_info.permutation is not None
+    enable_pdl = lora_pdl_enabled()
     _gate_up_lora_b_kernel[grid_b](
         x,
         gate_up_lora_b,
@@ -199,6 +205,8 @@ def gate_up_lora_b_fwd(
         BLOCK_OUT,
         BLOCK_R,
         batch_info.scalings,
+        enable_pdl,
+        **lora_pdl_launch_kwargs(enable_pdl),
     )
 
     return output

--- a/python/sglang/srt/lora/triton_ops/kernel_utils.py
+++ b/python/sglang/srt/lora/triton_ops/kernel_utils.py
@@ -1,6 +1,26 @@
 import triton
 import triton.language as tl
 
+from sglang.jit_kernel.utils import is_arch_support_pdl
+from sglang.srt.environ import envs
+
+
+def lora_pdl_enabled() -> bool:
+    """Whether to launch the LoRA Triton kernels with Programmatic Dependent Launch.
+
+    Opt-in via ``SGLANG_LORA_ENABLE_PDL`` and AND'd with the arch check
+    (``is_arch_support_pdl()`` is Hopper+, and False on HIP/MUSA where the
+    ``launch_pdl`` launch kwarg would be rejected). Read per launch so the env
+    var can be flipped/overridden at runtime; the arch probe is cached.
+    """
+    return bool(envs.SGLANG_LORA_ENABLE_PDL.get()) and is_arch_support_pdl()
+
+
+def lora_pdl_launch_kwargs(enable_pdl: bool) -> dict:
+    """``launch_pdl`` is an NVIDIA-only launch kwarg; the HIP backend rejects
+    unknown kwargs, so only pass it when PDL is actually enabled."""
+    return {"launch_pdl": True} if enable_pdl else {}
+
 
 @triton.jit
 def _resolve_token_positions(

--- a/python/sglang/srt/lora/triton_ops/kv_b_lora_absorbed.py
+++ b/python/sglang/srt/lora/triton_ops/kv_b_lora_absorbed.py
@@ -48,7 +48,11 @@ import torch
 import triton
 import triton.language as tl
 
-from sglang.srt.lora.triton_ops.kernel_utils import _resolve_token_positions
+from sglang.srt.lora.triton_ops.kernel_utils import (
+    _resolve_token_positions,
+    lora_pdl_enabled,
+    lora_pdl_launch_kwargs,
+)
 from sglang.srt.lora.utils import LoRABatchInfo
 
 # ---------------------------------------------------------------------------
@@ -71,10 +75,6 @@ from sglang.srt.lora.utils import LoRABatchInfo
 # ---------------------------------------------------------------------------
 
 _BLOCK_S = 16
-_STEP_A_BLOCK_K = 64  # contraction over qk_nope (~128) or kv_lora_rank (~512)
-_STEP_A_BLOCK_N = 16  # output is rank
-_STEP_B_BLOCK_K = 16  # contraction is rank
-_STEP_B_BLOCK_N = 64  # output is kv_lora_rank (~512) or v_head_dim (~128)
 
 
 def _num_segments(batch_info: LoRABatchInfo) -> int:
@@ -136,6 +136,7 @@ def _step_a_q_kernel(
     BLOCK_S: tl.constexpr,
     BLOCK_N: tl.constexpr,
     BLOCK_K: tl.constexpr,
+    ENABLE_PDL: tl.constexpr,
 ):
     batch_id = tl.program_id(axis=2)
     head_id = tl.program_id(axis=1)
@@ -182,6 +183,11 @@ def _step_a_q_kernel(
         head_id * FULL_K
     )  # row offset for this head's K-half (i in [0, qk_nope))
 
+    # PDL: static routing/index setup runs in the prologue; wait before the
+    # K-loop reads the dynamic `x` (q_nope, still being written upstream).
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_wait()
+
     partial_sum = tl.zeros((BLOCK_S, BLOCK_N), dtype=tl.float32)
     for k_block in range(0, tl.cdiv(K, BLOCK_K)):
         cur_k = k_block * BLOCK_K + k_offset
@@ -220,6 +226,9 @@ def _step_a_q_kernel(
     out_mask = row_mask[:, None] & (n_offset[None, :] < N_eff)
     tl.store(out + out_offs, partial_sum, mask=out_mask)
 
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_launch_dependents()
+
 
 def step_a_q_fwd(
     q_nope: torch.Tensor,
@@ -239,7 +248,9 @@ def step_a_q_fwd(
         ``(S, H, rank)`` -- per-token, per-head low-rank intermediate, ready for step B_q.
     """
     S, H, qk_nope_dim = q_nope.shape
+    _STEP_A_BLOCK_K = min(256, triton.next_power_of_2(qk_nope_dim))
     rank = B_buf.shape[-1]
+    _STEP_A_BLOCK_N = triton.next_power_of_2(rank)
     out = torch.empty((S, H, rank), device=q_nope.device, dtype=q_nope.dtype)
     num_segments = _num_segments(batch_info)
     max_segment_len = _max_segment_len(batch_info)
@@ -251,6 +262,7 @@ def step_a_q_fwd(
         segment_grid,
     )
     sorted_by_adapter = batch_info.permutation is not None
+    enable_pdl = lora_pdl_enabled()
 
     _step_a_q_kernel[grid](
         q_nope,
@@ -279,6 +291,8 @@ def step_a_q_fwd(
         BLOCK_S=_BLOCK_S,
         BLOCK_N=_STEP_A_BLOCK_N,
         BLOCK_K=_STEP_A_BLOCK_K,
+        ENABLE_PDL=enable_pdl,
+        **lora_pdl_launch_kwargs(enable_pdl),
     )
     return out
 
@@ -325,6 +339,7 @@ def _step_b_q_kernel(
     BLOCK_S: tl.constexpr,
     BLOCK_N: tl.constexpr,
     BLOCK_K: tl.constexpr,
+    ENABLE_PDL: tl.constexpr,
 ):
     batch_id = tl.program_id(axis=2)
     head_id = tl.program_id(axis=1)
@@ -367,6 +382,20 @@ def _step_b_q_kernel(
     n_mask = n_offset[None, :] < N
     safe_n = tl.minimum(n_offset, N - 1)
 
+    # Accumulate into base[s, h, n].
+    base_offs = (
+        safe_row[:, None] * b_stride_s
+        + head_id * b_stride_h
+        + safe_n[None, :] * b_stride_n
+    )
+    out_mask = row_mask[:, None] & n_mask
+
+    # PDL: static routing/index setup runs in the prologue; wait before the
+    # K-loop reads the dynamic `x` (step-A output) and the accumulate-base read
+    # below. The shared-A weight streams in the loop interleaved with `x`.
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_wait()
+
     partial_sum = tl.zeros((BLOCK_S, BLOCK_N), dtype=tl.float32)
     for k_block in range(0, tl.cdiv(K_eff, BLOCK_K)):
         cur_k = k_block * BLOCK_K + k_offset
@@ -398,15 +427,10 @@ def _step_b_q_kernel(
     partial_sum *= scaling
     partial_sum = partial_sum.to(x.dtype.element_ty)
 
-    # Accumulate into base[s, h, n].
-    base_offs = (
-        safe_row[:, None] * b_stride_s
-        + head_id * b_stride_h
-        + safe_n[None, :] * b_stride_n
-    )
-    out_mask = row_mask[:, None] & n_mask
-    partial_sum += tl.load(base + base_offs, mask=out_mask, other=0.0)
-    tl.store(base + base_offs, partial_sum, mask=out_mask)
+    tl.atomic_add(base + base_offs, partial_sum, mask=out_mask, sem="relaxed")
+
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_launch_dependents()
 
 
 def step_b_q_fwd(
@@ -428,7 +452,9 @@ def step_b_q_fwd(
         ``base_output`` (same object, mutated).
     """
     S, H, rank = q_lora_a.shape
+    _STEP_B_BLOCK_K = triton.next_power_of_2(rank)
     kv_lora_rank = A_buf.shape[-1]
+    _STEP_B_BLOCK_N = min(256, triton.next_power_of_2(kv_lora_rank))
     num_segments = _num_segments(batch_info)
     max_segment_len = _max_segment_len(batch_info)
     segment_grid = _segment_grid_size(batch_info, num_segments)
@@ -440,6 +466,7 @@ def step_b_q_fwd(
         segment_grid,
     )
     sorted_by_adapter = batch_info.permutation is not None
+    enable_pdl = lora_pdl_enabled()
 
     _step_b_q_kernel[grid](
         q_lora_a,
@@ -467,6 +494,8 @@ def step_b_q_fwd(
         BLOCK_S=_BLOCK_S,
         BLOCK_N=_STEP_B_BLOCK_N,
         BLOCK_K=_STEP_B_BLOCK_K,
+        ENABLE_PDL=enable_pdl,
+        **lora_pdl_launch_kwargs(enable_pdl),
     )
     return base_output
 
@@ -512,6 +541,7 @@ def _step_a_v_kernel(
     BLOCK_S: tl.constexpr,
     BLOCK_N: tl.constexpr,
     BLOCK_K: tl.constexpr,
+    ENABLE_PDL: tl.constexpr,
 ):
     batch_id = tl.program_id(axis=2)
     head_id = tl.program_id(axis=1)
@@ -552,6 +582,11 @@ def _step_a_v_kernel(
     safe_row = tl.minimum(s_physical, S - 1)
     safe_n = tl.minimum(n_offset, N_eff - 1)
 
+    # PDL: static routing/index setup runs in the prologue; wait before the
+    # K-loop reads the dynamic `x` (attn_output, still being written upstream).
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_wait()
+
     partial_sum = tl.zeros((BLOCK_S, BLOCK_N), dtype=tl.float32)
     for k_block in range(0, tl.cdiv(K, BLOCK_K)):
         cur_k = k_block * BLOCK_K + k_offset
@@ -591,6 +626,9 @@ def _step_a_v_kernel(
     out_mask = row_mask[:, None] & (n_offset[None, :] < N_eff)
     tl.store(out + out_offs, partial_sum, mask=out_mask)
 
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_launch_dependents()
+
 
 def step_a_v_fwd(
     attn_output: torch.Tensor,
@@ -608,7 +646,9 @@ def step_a_v_fwd(
         ``(S, H, rank)`` -- per-token, per-head low-rank intermediate for step B_v.
     """
     S, H, kv_lora_rank = attn_output.shape
+    _STEP_A_BLOCK_K = min(256, triton.next_power_of_2(kv_lora_rank))
     rank = A_buf.shape[1]
+    _STEP_A_BLOCK_N = triton.next_power_of_2(rank)
     out = torch.empty((S, H, rank), device=attn_output.device, dtype=attn_output.dtype)
     num_segments = _num_segments(batch_info)
     max_segment_len = _max_segment_len(batch_info)
@@ -620,6 +660,7 @@ def step_a_v_fwd(
         segment_grid,
     )
     sorted_by_adapter = batch_info.permutation is not None
+    enable_pdl = lora_pdl_enabled()
 
     _step_a_v_kernel[grid](
         attn_output,
@@ -646,6 +687,8 @@ def step_a_v_fwd(
         BLOCK_S=_BLOCK_S,
         BLOCK_N=_STEP_A_BLOCK_N,
         BLOCK_K=_STEP_A_BLOCK_K,
+        ENABLE_PDL=enable_pdl,
+        **lora_pdl_launch_kwargs(enable_pdl),
     )
     return out
 
@@ -695,6 +738,7 @@ def _step_b_v_kernel(
     BLOCK_S: tl.constexpr,
     BLOCK_N: tl.constexpr,
     BLOCK_K: tl.constexpr,
+    ENABLE_PDL: tl.constexpr,
 ):
     batch_id = tl.program_id(axis=2)
     head_id = tl.program_id(axis=1)
@@ -739,6 +783,12 @@ def _step_b_v_kernel(
     # V-half row base for this head: h*FULL_K + qk_nope
     head_row_base = head_id * FULL_K + QK_NOPE_OFFSET
 
+    # PDL: static routing/index setup runs in the prologue; wait before the
+    # K-loop reads the dynamic `x` (step-A_v output) and the accumulate-base read
+    # below. The V-half B weight streams in the loop interleaved with `x`.
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_wait()
+
     partial_sum = tl.zeros((BLOCK_S, BLOCK_N), dtype=tl.float32)
     for k_block in range(0, tl.cdiv(K_eff, BLOCK_K)):
         cur_k = k_block * BLOCK_K + k_offset
@@ -780,6 +830,9 @@ def _step_b_v_kernel(
     partial_sum += tl.load(base + base_offs, mask=out_mask, other=0.0)
     tl.store(base + base_offs, partial_sum, mask=out_mask)
 
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_launch_dependents()
+
 
 def step_b_v_fwd(
     attn_lora_a: torch.Tensor,
@@ -804,7 +857,9 @@ def step_b_v_fwd(
         ``base_output`` (same object, mutated).
     """
     S, H, rank = attn_lora_a.shape
+    _STEP_B_BLOCK_K = triton.next_power_of_2(rank)
     full_K_per_head = qk_nope_head_dim + v_head_dim
+    _STEP_B_BLOCK_N = triton.next_power_of_2(v_head_dim)
     num_segments = _num_segments(batch_info)
     max_segment_len = _max_segment_len(batch_info)
     segment_grid = _segment_grid_size(batch_info, num_segments)
@@ -816,6 +871,7 @@ def step_b_v_fwd(
         segment_grid,
     )
     sorted_by_adapter = batch_info.permutation is not None
+    enable_pdl = lora_pdl_enabled()
 
     _step_b_v_kernel[grid](
         attn_lora_a,
@@ -845,5 +901,7 @@ def step_b_v_fwd(
         BLOCK_S=_BLOCK_S,
         BLOCK_N=_STEP_B_BLOCK_N,
         BLOCK_K=_STEP_B_BLOCK_K,
+        ENABLE_PDL=enable_pdl,
+        **lora_pdl_launch_kwargs(enable_pdl),
     )
     return base_output

--- a/python/sglang/srt/lora/triton_ops/qkv_lora_b.py
+++ b/python/sglang/srt/lora/triton_ops/qkv_lora_b.py
@@ -2,7 +2,11 @@ import torch
 import triton
 import triton.language as tl
 
-from sglang.srt.lora.triton_ops.kernel_utils import _resolve_token_positions
+from sglang.srt.lora.triton_ops.kernel_utils import (
+    _resolve_token_positions,
+    lora_pdl_enabled,
+    lora_pdl_launch_kwargs,
+)
 from sglang.srt.lora.utils import LoRABatchInfo
 
 
@@ -38,6 +42,7 @@ def _qkv_lora_b_kernel(
     BLOCK_K: tl.constexpr,
     # For fused output scaling
     scalings,
+    ENABLE_PDL: tl.constexpr,
 ):
     """
     This kernel packs 3 sgemms (q/k/v) into a single kernel. The multiplication
@@ -106,6 +111,17 @@ def _qkv_lora_b_kernel(
     w_ptrs = (weights + w_index * w_stride_0 + n_start * w_stride_1) + (
         k_offset[:, None] * w_stride_2 + n_offset[None, :] * w_stride_1
     )
+    output_ptr = (
+        output
+        + n_start * output_stride_1
+        + (s_physical[:, None] * output_stride_0 + n_offset[None, :] * output_stride_1)
+    )
+    output_mask = (s_offset[:, None] < seg_len) & (n_offset[None, :] < n_size)
+
+    # PDL: static routing/pointer setup runs in the prologue; wait before the
+    # K-loop reads the dynamic shrink output `x` (still being written upstream).
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_wait()
 
     # Iterate to compute the block in output matrix
     partial_sum = tl.zeros((BLOCK_S, BLOCK_N), dtype=tl.float32)
@@ -128,14 +144,10 @@ def _qkv_lora_b_kernel(
     # Store result to output matrix
     partial_sum *= scaling
     partial_sum = partial_sum.to(x.dtype.element_ty)
-    output_ptr = (
-        output
-        + n_start * output_stride_1
-        + (s_physical[:, None] * output_stride_0 + n_offset[None, :] * output_stride_1)
-    )
-    output_mask = (s_offset[:, None] < seg_len) & (n_offset[None, :] < n_size)
-    partial_sum += tl.load(output_ptr, mask=output_mask)
-    tl.store(output_ptr, partial_sum, mask=output_mask)
+    tl.atomic_add(output_ptr, partial_sum, mask=output_mask, sem="relaxed")
+
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_launch_dependents()
 
 
 def qkv_lora_b_fwd(
@@ -187,6 +199,7 @@ def qkv_lora_b_fwd(
         output = base_output
 
     sorted_by_adapter = batch_info.permutation is not None
+    enable_pdl = lora_pdl_enabled()
     _qkv_lora_b_kernel[grid_b](
         x,
         qkv_lora_b,
@@ -211,6 +224,8 @@ def qkv_lora_b_fwd(
         BLOCK_OUT,
         BLOCK_R,
         batch_info.scalings,
+        enable_pdl,
+        **lora_pdl_launch_kwargs(enable_pdl),
     )
 
     return output

--- a/python/sglang/srt/lora/triton_ops/sgemm_lora_a.py
+++ b/python/sglang/srt/lora/triton_ops/sgemm_lora_a.py
@@ -5,7 +5,11 @@ import triton
 import triton.language as tl
 
 from sglang.srt.environ import envs
-from sglang.srt.lora.triton_ops.kernel_utils import _resolve_token_positions
+from sglang.srt.lora.triton_ops.kernel_utils import (
+    _resolve_token_positions,
+    lora_pdl_enabled,
+    lora_pdl_launch_kwargs,
+)
 from sglang.srt.lora.utils import LoRABatchInfo
 
 
@@ -38,6 +42,7 @@ def _sgemm_lora_a_kernel(
     BLOCK_S: tl.constexpr,
     BLOCK_N: tl.constexpr,
     BLOCK_K: tl.constexpr,
+    ENABLE_PDL: tl.constexpr,
 ):
     """
     Computes a segmented batched matrix multiplication for the LoRA A matrix.
@@ -95,6 +100,14 @@ def _sgemm_lora_a_kernel(
         k_offset[:, None] * w_stride_2 + n_offset[None, :] * w_stride_1
     )
 
+    output_mask = (s_offset[:, None] < seg_len) & (n_offset[None, :] < N)
+    output_ptr = output + (
+        s_physical[:, None] * output_stride_0 + n_offset[None, :] * output_stride_1
+    )
+
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_wait()
+
     # Iterate to compute the block in output matrix
     partial_sum = tl.zeros((BLOCK_S, BLOCK_N), dtype=tl.float32)
     for k in range(0, tl.cdiv(K, BLOCK_K)):
@@ -115,11 +128,10 @@ def _sgemm_lora_a_kernel(
 
     # Store result to output matrix
     partial_sum = partial_sum.to(x.dtype.element_ty)
-    output_mask = (s_offset[:, None] < seg_len) & (n_offset[None, :] < N)
-    output_ptr = output + (
-        s_physical[:, None] * output_stride_0 + n_offset[None, :] * output_stride_1
-    )
     tl.store(output_ptr, partial_sum, mask=output_mask)
+
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_launch_dependents()
 
 
 @triton.jit
@@ -147,6 +159,7 @@ def _sgemm_lora_a_splitk_kernel(
     BLOCK_N: tl.constexpr,
     BLOCK_K: tl.constexpr,
     SPLIT_K: tl.constexpr,
+    ENABLE_PDL: tl.constexpr,
 ):
     """Split-K variant of ``_sgemm_lora_a_kernel`` for the under-filled decode shape.
 
@@ -189,6 +202,14 @@ def _sgemm_lora_a_splitk_kernel(
         offs_k[:, None] * w_stride_2 + n_offset[None, :] * w_stride_1
     )
 
+    out_mask = (s_offset[:, None] < seg_len) & (n_offset[None, :] < N)
+    out_ptr = output + (
+        s_physical[:, None] * output_stride_0 + n_offset[None, :] * output_stride_1
+    )
+
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_wait()
+
     grid_k = tl.cdiv(K, BLOCK_K * SPLIT_K)
     partial_sum = tl.zeros((BLOCK_S, BLOCK_N), dtype=tl.float32)
     for k in range(0, grid_k):
@@ -207,11 +228,10 @@ def _sgemm_lora_a_splitk_kernel(
         x_ptrs += BLOCK_K * SPLIT_K * x_stride_1
         w_ptrs += BLOCK_K * SPLIT_K * w_stride_2
 
-    out_mask = (s_offset[:, None] < seg_len) & (n_offset[None, :] < N)
-    out_ptr = output + (
-        s_physical[:, None] * output_stride_0 + n_offset[None, :] * output_stride_1
-    )
     tl.atomic_add(out_ptr, partial_sum, mask=out_mask, sem="relaxed")
+
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_launch_dependents()
 
 
 @functools.lru_cache(maxsize=None)
@@ -274,6 +294,9 @@ def sgemm_lora_a_fwd(
 
     sorted_by_adapter = batch_info.permutation is not None
 
+    enable_pdl = lora_pdl_enabled()
+    pdl_kwargs = lora_pdl_launch_kwargs(enable_pdl)
+
     split_k = 1
     if envs.SGLANG_ENABLE_LORA_SHRINK_SPLIT_K.get() and x.is_cuda:
         split_k = _lora_a_split_k(
@@ -314,6 +337,8 @@ def sgemm_lora_a_fwd(
             BLOCK_R,
             BLOCK_K,
             split_k,
+            enable_pdl,
+            **pdl_kwargs,
         )
         return acc.to(x.dtype)
 
@@ -341,5 +366,7 @@ def sgemm_lora_a_fwd(
         BLOCK_S,
         BLOCK_R,
         BLOCK_K,
+        enable_pdl,
+        **pdl_kwargs,
     )
     return output

--- a/python/sglang/srt/lora/triton_ops/sgemm_lora_b.py
+++ b/python/sglang/srt/lora/triton_ops/sgemm_lora_b.py
@@ -2,7 +2,11 @@ import torch
 import triton
 import triton.language as tl
 
-from sglang.srt.lora.triton_ops.kernel_utils import _resolve_token_positions
+from sglang.srt.lora.triton_ops.kernel_utils import (
+    _resolve_token_positions,
+    lora_pdl_enabled,
+    lora_pdl_launch_kwargs,
+)
 from sglang.srt.lora.utils import LoRABatchInfo
 
 
@@ -36,6 +40,7 @@ def _sgemm_lora_b_kernel(
     BLOCK_K: tl.constexpr,
     # For fused output scaling
     scalings,
+    ENABLE_PDL: tl.constexpr,
 ):
     """
     Computes a segmented batched matrix multiplication for the LoRA B matrix
@@ -94,34 +99,41 @@ def _sgemm_lora_b_kernel(
         k_offset[:, None] * w_stride_2 + n_offset[None, :] * w_stride_1
     )
 
-    # Iterate to compute the block in output matrix
     n_mask = n_offset[None, :] < N
-    partial_sum = tl.zeros((BLOCK_S, BLOCK_N), dtype=tl.float32)
-    for k in range(0, tl.cdiv(K, BLOCK_K)):
-        x_tile = tl.load(
-            x_ptrs,
-            mask=(s_offset[:, None] < seg_len) & (k_offset[None, :] < K - k * BLOCK_K),
-            other=0.0,
-        )
-        w_tile = tl.load(
-            w_ptrs,
-            mask=(k_offset[:, None] < K - k * BLOCK_K) & n_mask,
-            other=0.0,
-        )
-        partial_sum += tl.dot(x_tile, w_tile)
-
-        x_ptrs += BLOCK_K * x_stride_1
-        w_ptrs += BLOCK_K * w_stride_2
-
-    # Store result to output matrix
-    partial_sum *= scaling
-    partial_sum = partial_sum.to(x.dtype.element_ty)
     output_ptr = output + (
         s_physical[:, None] * output_stride_0 + n_offset[None, :] * output_stride_1
     )
     output_mask = (s_offset[:, None] < seg_len) & n_mask
-    partial_sum += tl.load(output_ptr, mask=output_mask, other=0.0)
-    tl.store(output_ptr, partial_sum, mask=output_mask)
+
+    # PDL: the LoRA-B weight is a static pool buffer and the routing metadata is
+    # prepared upstream, so load the weight in the prologue to overlap it with
+    # the producing shrink kernel's tail. There is exactly one K-tile here
+    # (BLOCK_K = next_pow2(rank) >= rank >= K), so this single load covers the
+    # whole contraction. Wait only before reading the dynamic shrink output `x`
+    # and the fused-add base (which the immediately-preceding kernel may write).
+    w_tile = tl.load(
+        w_ptrs,
+        mask=(k_offset[:, None] < K) & n_mask,
+        other=0.0,
+    )
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_wait()
+    x_tile = tl.load(
+        x_ptrs,
+        mask=(s_offset[:, None] < seg_len) & (k_offset[None, :] < K),
+        other=0.0,
+    )
+    partial_sum = tl.dot(x_tile, w_tile)
+
+    # Store result to output matrix
+    partial_sum *= scaling
+    partial_sum = partial_sum.to(x.dtype.element_ty)
+    # partial_sum += tl.load(output_ptr, mask=output_mask, other=0.0)
+    # tl.store(output_ptr, partial_sum, mask=output_mask)
+    tl.atomic_add(output_ptr, partial_sum, mask=output_mask, sem="relaxed")
+
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_launch_dependents()
 
 
 def sgemm_lora_b_fwd(
@@ -161,6 +173,7 @@ def sgemm_lora_b_fwd(
         output = base_output
 
     sorted_by_adapter = batch_info.permutation is not None
+    enable_pdl = lora_pdl_enabled()
     _sgemm_lora_b_kernel[grid](
         x,
         weights,
@@ -184,5 +197,7 @@ def sgemm_lora_b_fwd(
         BLOCK_N,
         BLOCK_R,
         batch_info.scalings,
+        enable_pdl,
+        **lora_pdl_launch_kwargs(enable_pdl),
     )
     return output

--- a/python/sglang/srt/lora/triton_ops/virtual_experts.py
+++ b/python/sglang/srt/lora/triton_ops/virtual_experts.py
@@ -10,6 +10,10 @@ import triton
 import triton.language as tl
 
 from sglang.jit_kernel.moe_align import moe_align_block_size as jit_moe_align_block_size
+from sglang.srt.lora.triton_ops.kernel_utils import (
+    lora_pdl_enabled,
+    lora_pdl_launch_kwargs,
+)
 
 
 @triton.jit
@@ -25,6 +29,7 @@ def _fused_virtual_topk_ids_kernel(
     local_expert_offset: tl.constexpr,
     local_num_experts: tl.constexpr,
     EP_LOCAL: tl.constexpr,
+    ENABLE_PDL: tl.constexpr,
 ):
     """
     Fuses _get_virtual_topk_ids: comparison + clamp + arithmetic into one kernel.
@@ -45,6 +50,11 @@ def _fused_virtual_topk_ids_kernel(
 
     m = offs // top_k
     # k = offs % top_k  # not needed directly
+
+    # PDL: index arithmetic above is static; wait before reading the dynamic
+    # routing inputs (token_lora_mapping / topk_ids produced upstream).
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_wait()
 
     lora_id = tl.load(token_lora_mapping_ptr + m, mask=valid, other=0)
     mask_val = lora_id >= 0
@@ -73,6 +83,9 @@ def _fused_virtual_topk_ids_kernel(
     k = offs % top_k
     is_first_k = k == 0
     tl.store(token_lora_mask_ptr + m, mask_val, mask=valid & is_first_k)
+
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_launch_dependents()
 
 
 def _fused_virtual_topk_ids(
@@ -112,6 +125,7 @@ def _fused_virtual_topk_ids(
     BLOCK_SIZE = 1024
     grid = ((M * top_k + BLOCK_SIZE - 1) // BLOCK_SIZE,)
 
+    enable_pdl = lora_pdl_enabled()
     _fused_virtual_topk_ids_kernel[grid](
         input_topk,
         token_lora_mapping,
@@ -124,6 +138,8 @@ def _fused_virtual_topk_ids(
         local_expert_offset,
         local_num_experts if local_num_experts is not None else 0,
         ep_local,
+        enable_pdl,
+        **lora_pdl_launch_kwargs(enable_pdl),
     )
 
     virtual_num_experts = num_experts_for_weight * max_loras
@@ -137,14 +153,22 @@ def _fused_sanitize_expert_ids_kernel(
     num_virtual_experts,
     N,
     BLOCK_SIZE: tl.constexpr,
+    ENABLE_PDL: tl.constexpr,
 ):
     pid = tl.program_id(0)
     offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     valid = offs < N
 
+    # PDL: wait before reading the dynamic expert_ids (produced by the align kernel).
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_wait()
+
     eid = tl.load(expert_ids_ptr + offs, mask=valid, other=0)
     result = tl.where(eid < num_virtual_experts, eid, -1)
     tl.store(output_ptr + offs, result, mask=valid)
+
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_launch_dependents()
 
 
 def fused_sanitize_expert_ids(
@@ -162,12 +186,15 @@ def fused_sanitize_expert_ids(
     BLOCK_SIZE = 1024
     grid = ((N + BLOCK_SIZE - 1) // BLOCK_SIZE,)
 
+    enable_pdl = lora_pdl_enabled()
     _fused_sanitize_expert_ids_kernel[grid](
         expert_ids,
         output,
         num_virtual_experts,
         N,
         BLOCK_SIZE,
+        enable_pdl,
+        **lora_pdl_launch_kwargs(enable_pdl),
     )
     return output
 
@@ -200,6 +227,7 @@ def _moe_lora_shrink_splitk_kernel(
     BLOCK_SIZE_K: tl.constexpr,
     GROUP_SIZE_M: tl.constexpr,
     SPLIT_K: tl.constexpr,
+    ENABLE_PDL: tl.constexpr,
 ):
     """Split-K grouped GEMM for the LoRA A (shrink) stage with few virtual experts."""
     pid = tl.program_id(0)
@@ -241,6 +269,15 @@ def _moe_lora_shrink_splitk_kernel(
         + off_expert * stride_be
         + (offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn)
     )
+    offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = c_ptr + stride_cm * offs_token[:, None] + stride_cn * offs_cn[None, :]
+    c_mask = token_mask[:, None] & (offs_cn[None, :] < N)
+
+    # PDL: static routing/pointer setup runs in the prologue; wait before the
+    # K-loop reads the dynamic hidden states `a` (still being written upstream).
+    # The LoRA-A weight `b` streams in the loop interleaved with `a`.
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_wait()
 
     # Accumulate
     accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
@@ -261,13 +298,13 @@ def _moe_lora_shrink_splitk_kernel(
     accumulator = accumulator.to(c_ptr.dtype.element_ty)
 
     # Write output
-    offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
-    c_ptrs = c_ptr + stride_cm * offs_token[:, None] + stride_cn * offs_cn[None, :]
-    c_mask = token_mask[:, None] & (offs_cn[None, :] < N)
     if SPLIT_K == 1:
         tl.store(c_ptrs, accumulator, mask=c_mask)
     else:
         tl.atomic_add(c_ptrs, accumulator, mask=c_mask, sem="relaxed")
+
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_launch_dependents()
 
 
 def _invoke_moe_lora_shrink_splitk(
@@ -296,6 +333,7 @@ def _invoke_moe_lora_shrink_splitk(
 
     grid = (SPLIT_K * base_grid,)
 
+    enable_pdl = lora_pdl_enabled()
     _moe_lora_shrink_splitk_kernel[grid](
         hidden_states,
         weight,
@@ -319,8 +357,10 @@ def _invoke_moe_lora_shrink_splitk(
         BLOCK_SIZE_K=BLOCK_SIZE_K,
         GROUP_SIZE_M=GROUP_SIZE_M,
         SPLIT_K=SPLIT_K,
+        ENABLE_PDL=enable_pdl,
         num_warps=config.get("num_warps", 4),
         num_stages=config.get("num_stages", 4),
+        **lora_pdl_launch_kwargs(enable_pdl),
     )
 
 
@@ -347,7 +387,6 @@ from sglang.srt.lora.trtllm_moe.specialized_expand import (  # noqa: E402,F401
     _invoke_moe_lora_expand_add,
     _moe_lora_expand_add_kernel,
 )
-
 
 
 def _align_block_size_jit(

--- a/python/sglang/srt/lora/trtllm_moe/specialized_expand.py
+++ b/python/sglang/srt/lora/trtllm_moe/specialized_expand.py
@@ -19,6 +19,10 @@ import triton
 import triton.language as tl
 
 from sglang.srt.environ import envs
+from sglang.srt.lora.triton_ops.kernel_utils import (
+    lora_pdl_enabled,
+    lora_pdl_launch_kwargs,
+)
 
 
 @triton.jit
@@ -52,6 +56,7 @@ def _moe_lora_expand_add_kernel(
     BLOCK_SIZE_R: tl.constexpr,
     GROUP_SIZE_M: tl.constexpr,
     GATED_A_HALF: tl.constexpr,
+    ENABLE_PDL: tl.constexpr,
 ):
     """Rank-specialized LoRA-B expand for virtual-expert LoRA.
 
@@ -104,11 +109,6 @@ def _moe_lora_expand_add_kernel(
     if GATED_A_HALF > 0:
         a_col = offs_r + tl.where(pid_n * BLOCK_SIZE_N >= GATED_A_HALF, R, 0)
 
-    a = tl.load(
-        a_ptr + offs_token[:, None] * stride_am + a_col[None, :] * stride_ar,
-        mask=token_mask[:, None] & rank_mask[None, :],
-        other=0.0,
-    )
     b = tl.load(
         b_ptr
         + off_expert * stride_be
@@ -118,21 +118,37 @@ def _moe_lora_expand_add_kernel(
         other=0.0,
     )
 
-    accumulator = tl.dot(a, b, out_dtype=tl.float32)
-    if MUL_ROUTED_WEIGHT:
-        moe_weight = tl.load(topk_weights_ptr + offs_token, mask=token_mask, other=0.0)
-        accumulator *= moe_weight[:, None]
-
     if FUSE_SUM_ALL_REDUCE:
         offs_token_out = offs_token // router_topk
     else:
         offs_token_out = offs_token
+
     c_ptrs = c_ptr + offs_token_out[:, None] * stride_cm + offs_n[None, :] * stride_cn
     c_mask = token_mask[:, None] & (offs_n[None, :] < N)
+
+    if MUL_ROUTED_WEIGHT:
+        moe_weight = tl.load(topk_weights_ptr + offs_token, mask=token_mask, other=0.0)
+
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_wait()
+
+    a = tl.load(
+        a_ptr + offs_token[:, None] * stride_am + a_col[None, :] * stride_ar,
+        mask=token_mask[:, None] & rank_mask[None, :],
+        other=0.0,
+    )
+
+    accumulator = tl.dot(a, b, out_dtype=tl.float32)
+    if MUL_ROUTED_WEIGHT:
+        accumulator *= moe_weight[:, None]
+
     if FUSE_SUM_ALL_REDUCE:
         tl.atomic_add(c_ptrs, accumulator.to(c_ptr.dtype.element_ty), mask=c_mask)
     else:
         tl.store(c_ptrs, accumulator.to(c_ptr.dtype.element_ty), mask=c_mask)
+
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_launch_dependents()
 
 
 def _invoke_moe_lora_expand_add(
@@ -160,8 +176,8 @@ def _invoke_moe_lora_expand_add(
     R = weight.shape[2]
     assert R <= 64, f"direct LoRA expand/add expects rank <= 64, got {R}"
 
-    block_size_m = 16
-    block_size_n = 256
+    block_size_m = config["BLOCK_SIZE_M"]
+    block_size_n = config["BLOCK_SIZE_N"]
     group_size_m = config.get("GROUP_SIZE_M", 1)
     block_size_r = triton.next_power_of_2(R)
 
@@ -182,6 +198,7 @@ def _invoke_moe_lora_expand_add(
         * triton.cdiv(N, block_size_n),
     )
 
+    enable_pdl = lora_pdl_enabled()
     _moe_lora_expand_add_kernel[grid](
         intermediate,
         weight,
@@ -208,6 +225,8 @@ def _invoke_moe_lora_expand_add(
         BLOCK_SIZE_R=block_size_r,
         GROUP_SIZE_M=group_size_m,
         GATED_A_HALF=gated_a_half,
+        ENABLE_PDL=enable_pdl,
         num_warps=config.get("num_warps", 4),
         num_stages=1,
+        **lora_pdl_launch_kwargs(enable_pdl),
     )


### PR DESCRIPTION
## LoRA Triton kernel changes — PDL (opt-in), atomic-add expand, adaptive `kv_b` block sizes

Scoped to one commit (`9c219ae`) on top of the `lora-splitk-pr8` series. Base is the
pre-session commit (`4b6a72a` "manual tune") so the diff is **only** these kernel
changes (+320/−98, 10 files). It is **not** based on `sgl-project/sglang main`: this
branch is ~14 commits / 750 files behind/diverged from upstream main, so a real
upstream PR would need a rebase + extraction of just these hunks first.

### What's here

**1. Opt-in PDL — `SGLANG_LORA_ENABLE_PDL` (`EnvBool`, default off)**
Programmatic Dependent Launch on the LoRA kernels: dense shrink (`sgemm_lora_a`,
incl. split-K), expand (`sgemm_lora_b` / `qkv_lora_b` / `gate_up_lora_b`), absorbed
`kv_b` correction (`step_a/b_q/v`), MoE virtual-expert shrink/expand, and the
routing-prep kernels. Each loads its static inputs (LoRA weights + routing metadata)
in the prologue, `gdc_wait()`s before the dynamic activation, and
`gdc_launch_dependents()`s at the end. AND'd with `is_arch_support_pdl()` (Hopper+;
no-op on HIP/MUSA). Helpers `lora_pdl_enabled()` / `lora_pdl_launch_kwargs()` in
`triton_ops/kernel_utils.py`.
**Measured ~neutral E2E** (Kimi-K2.5-NVFP4, tp8, bs64: −0.26%, noise), so it ships
**off** as a knob for further overlap work (the genuine win needs a producer-only
shrink / consumer expand split, not the blanket gate).

**2. LoRA-B expand fused base-add via `atomic_add`**
`sgemm_lora_b` is a single K-tile (`BLOCK_K = next_pow2(rank) ≥ rank`), so the K-loop
is replaced by a straight line and the base read+add+store becomes a relaxed
`atomic_add`. This drops the output-read stall from the critical path (~7–13% faster
expand on B200). `qkv_lora_b` / `gate_up_lora_b` adopt the same fused `atomic_add`.
Correct in the dense path: each `(token, n)` output tile has exactly one writer
(ordered after the base GEMM on the same stream).

**3. Absorbed `kv_b` adaptive block sizes**
`step_a/b_{q,v}` derive `BLOCK_K`/`BLOCK_N` from the real per-step dims via
`next_power_of_2` (contraction K and output N), wide contractions capped at 256,
instead of fixed constants; `step_b` accumulates into base via `atomic_add`.

### Testing
Correctness validated on B200 (PDL on == off, bit-identical, matches fp32 reference)
for the shrink and `step_a` kernels via a scratch harness (not included). No direct
unit test exists for the absorbed `kv_b` kernels yet — only indirect E2E coverage via
`test/registered/lora/test_lora_kimi_k25_logprob_diff.py`. A direct registered kernel
test (à la `test_virtual_experts_kernels.py`) is a recommended follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Investigated (this session): does a `num_adapter==1` cuBLAS fast path beat these Triton expands?

For a single loaded adapter every token routes to slot 0, so the segmented SGMM
collapses to a plain dense GEMM. The pool already zeroes the B `[rank:]` tail, so a
cuBLAS path contracting over the full padded `R` is **bit-identical** to Triton
(`max_err = 0.0000` everywhere below). Scaling is folded into `x` on-device and slice
offsets baked as host ints, so the path is CUDA-graph capturable (indexing the GPU
`output_offset` forces an illegal capture-time sync). Benched triton-vs-cublas on B200
with `do_bench` (cuda-graph + L2-cold). `speedup = triton_us / cublas_us` (>1 ⇒ cuBLAS wins):

**`sgemm_lora_b` — cuBLAS LOSES across decode; keep Triton.**

| regime | speedup | winner |
|---|---|---|
| bs 1–64, N 896/2304, rank 16–64 | 0.45–0.87 | Triton (1.2–2.4×) |
| bs=128 + N=2304 + rank=64 | 1.63 | cuBLAS (compute-bound tail) |

The expand's contraction `K = rank` is tiny (16–64), a "fat, tiny-K" GEMM that
under-utilizes cuBLAS and pays its ~3.2 µs launch/heuristic floor — more than Triton's
whole ~1.9–2.6 µs runtime. (Opposite of the LoRA-A *shrink*, where the large-K
contraction lets `F.linear` win 1.2–1.7×.) **No dispatch added** — `sgemm_lora_b.py`
is unchanged; a `weights.shape[0]==1 → addmm` branch was prototyped then reverted
because it regresses decode ~1.5–2×.

**`qkv_lora_b` — shape-dependent; cuBLAS wins high-batch + prefill, loses low-bs decode.**

| shape | bs≤32 decode | bs 64–128 | prefill (seg 512/2048) |
|---|---|---|---|
| TP8 GQA per-GPU, N=768 | Triton (0.5–0.8) | cuBLAS from bs128 (1.2–1.8×) | cuBLAS (1.3–1.8×) |
| Kimi single-slice, N=1536 | ~tie (0.9–1.3) | cuBLAS (1.7–3.0×) | cuBLAS (1.9–3.2×) |
| full GQA, N=6144 (no TP) | cuBLAS from bs16 | cuBLAS up to **9.8×** | cuBLAS (3–6×) |

The fused qkv kernel tiles each length-1 decode segment independently (grid axis2 = bs,
`BLOCK_S=16` wastes 15/16 rows, × `n_slices` × `BLOCK_OUT=64` fine N-tiles), so its real
GPU time grows ~linearly with bs (45–81 µs at bs=128, N=6144) while the dense cuBLAS path
stays flat ~7 µs. A **bs/seg-gated** cuBLAS dispatch for `qkv_lora_b` is a plausible
follow-up (helps high-concurrency decode + prefill), but it is not a clean low-bs decode
win and is left out of this PR.

Benches added (standalone, not wired into CI): `bench_sgemm_lora_b_cublas.py`,
`bench_qkv_lora_b_cublas.py` (`--slice-dims`).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
